### PR TITLE
Update CodecJLayerMP3.java

### DIFF
--- a/src/de/cuina/fireandfuel/CodecJLayerMP3.java
+++ b/src/de/cuina/fireandfuel/CodecJLayerMP3.java
@@ -210,7 +210,7 @@ public class CodecJLayerMP3 implements ICodec
 			{
 				myAudioInputStream.execute();
 				if((cnt = myAudioInputStream.read(streamBuffer, bytesRead, streamBuffer.length
-						- bytesRead)) <= 0)
+						- bytesRead)) < 0)
 				{
 					endOfStream(SET, true);
 					break;
@@ -316,7 +316,7 @@ public class CodecJLayerMP3 implements ICodec
 					{
 						myAudioInputStream.execute();
 						if((cnt = myAudioInputStream.read(smallBuffer, bytesRead,
-								smallBuffer.length - bytesRead)) <= 0)
+								smallBuffer.length - bytesRead)) < 0)
 						{
 							endOfStream(SET, true);
 							break;


### PR DESCRIPTION
Fixed a Bug where mp3-Files do not Play because "cnt" is 0 when trying to read the File (see http://www.javazoom.net/mp3spi/documents.html)
